### PR TITLE
update dependency name for windows

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -8,7 +8,7 @@
     ;; NB: not supporting 386 platforms at this point, unless requested...
     ("portaudio-x86_64-macosx"  #:platform "x86_64-macosx")
     ("portaudio-x86_64-linux"   #:platform "x86_64-linux")
-    ("portaudio-x86_64-windows" #:platform "win32\\x86_64")
+    ("portaudio-x86_64-win32" #:platform "win32\\x86_64")
     ))
 
 (define build-deps


### PR DESCRIPTION
I was unable to install the windows version

Error message:

```
>raco pkg install portaudio
Resolving "portaudio" via https://download.racket-lang.org/releases/7.7/catalog/
Resolving "portaudio" via https://pkgs.racket-lang.org
Using cached15953716251595371625869 for github://github.com/jbclements/portaudio/master/
The following uninstalled packages are listed as dependencies of portaudio:
   portaudio-x86_64-windows
Would you like to install these dependencies? [Y/n/a/c/?] a
Resolving "portaudio-x86_64-windows" via https://download.racket-lang.org/releases/7.7/catalog/
Resolving "portaudio-x86_64-windows" via https://pkgs.racket-lang.org
Resolving "portaudio-x86_64-windows" via https://planet-compats.racket-lang.org
raco pkg install: cannot find package on catalogs
  package: portaudio-x86_64-windows
```

The problem is probably in the name of the dependency for windows.